### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In order to use this library from you Android project using maven your pom shoul
 </project>
 ```
 
-###Normal integration
+### Normal integration
 
 Refer to the downloads section to get a JAR to import to your project.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
